### PR TITLE
Add awscost-release skill for cutting PyPI releases

### DIFF
--- a/.claude/skills/awscost-release/SKILL.md
+++ b/.claude/skills/awscost-release/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: awscost-release
+description: Release awscost to PyPI. Bumps the version in pyproject.toml, commits it to master, and pushes a matching git tag (vX.Y.Z) that triggers the "release" GitHub Actions workflow (Trusted Publisher / OIDC, no token). The tag is always derived from pyproject.toml so the two never drift. Use for cutting a release, releasing, publishing to PyPI, bumping the version and tagging.
+---
+
+# awscost-release (cut a PyPI release)
+
+Bump version → commit → push tag → GitHub Actions publishes to PyPI.
+
+The whole flow is one script — [`release.sh`](release.sh). It is deterministic, so run it
+rather than doing the steps by hand:
+
+```bash
+.claude/skills/awscost-release/release.sh [patch|minor|major|X.Y.Z]
+```
+
+- (none) or `patch` → bump the patch part (`0.4.0` → `0.4.1`)
+- `minor` → `0.5.0`
+- `major` → `1.0.0`
+- an explicit `X.Y.Z` → set that exact version
+
+**The git tag is always derived from `pyproject.toml`'s `version` as `v<version>`**, so the
+tag and the packaged version never drift. `pyproject.toml` is the single source of truth.
+
+## What the script does
+
+1. Guards the working state: on `master`, clean tree, up to date with origin.
+2. Reads the current version and computes the new one from the argument.
+3. Stops on collision: tag already exists (local/origin) or version already on PyPI.
+4. Edits the `version` line in `pyproject.toml`.
+5. Sanity gate (mirrors `scripts/ci.sh run-test`): `ruff check src tests`,
+   `ruff format --check --diff ./`, `pytest -q`; reverts `pyproject.toml` and stops on failure.
+6. Commits `pyproject.toml` to `master` as `Release v<new>`, tags `v<new>` locally,
+   then pushes `master`.
+7. Pushes the tag — this is what triggers the `release` workflow.
+8. Polls PyPI (~5 min) until `<new>` appears, then reports `https://pypi.org/project/awscost/<new>/`.
+
+## Notes
+
+- Releasing commits directly to `master` — the intentional exception to the "no direct work on
+  master" rule. The script enforces the commit-before-tag order the publish workflow needs.
+- Publishing is via PyPI Trusted Publisher (OIDC); no API token or `gh` is needed. It relies on
+  the trusted publisher registered for `awscost` and the GitHub `pypi` Environment.
+- `ruff` and `pytest` must be on PATH (`pip install ".[test]"` / `scripts/ci.sh install-test`).
+- Confirm the new version with the user before running when the bump level is ambiguous.
+- If publish fails with `File already exists`, that version is already on PyPI — bump again.
+- Exit codes: `0` = published and confirmed; `2` = committed and tagged but PyPI not confirmed
+  within the poll window (the publish is likely still running — check Actions, do **not** re-bump);
+  `1` = a guard/gate failed before anything was pushed.
+- If `master` is pushed but the tag push fails, the tag already exists locally — recover with
+  `git push origin v<new>`; do not re-run the script (it would bump to the next version).

--- a/.claude/skills/awscost-release/release.sh
+++ b/.claude/skills/awscost-release/release.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# Cut a PyPI release for awscost.
+#
+# Bump pyproject.toml's version -> commit to master -> push a matching
+# v<version> tag, which triggers the "release" GitHub Actions workflow
+# (Trusted Publisher / OIDC, no token). The tag is always derived from
+# pyproject.toml so the two never drift.
+#
+# Usage:
+#   release.sh [patch|minor|major|X.Y.Z]
+#   (no argument defaults to "patch")
+#
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+BUMP="${1:-patch}"
+
+die() { echo "release: $*" >&2; exit 1; }
+
+# --- Step 0: guard the working state ----------------------------------------
+[[ "$(git branch --show-current)" == "master" ]] || die "not on master"
+[[ -z "$(git status --porcelain)" ]] || die "working tree is not clean"
+git fetch origin
+[[ "$(git rev-parse @)" == "$(git rev-parse '@{u}')" ]] || die "local master is not up to date with origin"
+
+# --- Step 1: read the current version ---------------------------------------
+CUR="$(grep -E '^version = "' pyproject.toml | head -1 | sed -E 's/^version = "([^"]+)".*/\1/')"
+[[ "$CUR" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "unexpected version in pyproject.toml: '$CUR' (expected X.Y.Z)"
+
+# --- Step 2: compute the new version ----------------------------------------
+if [[ "$BUMP" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  NEW="$BUMP"
+else
+  IFS='.' read -r MAJ MIN PAT <<<"$CUR"
+  case "$BUMP" in
+    major) NEW="$((MAJ + 1)).0.0" ;;
+    minor) NEW="${MAJ}.$((MIN + 1)).0" ;;
+    patch) NEW="${MAJ}.${MIN}.$((PAT + 1))" ;;
+    *) die "unknown bump '$BUMP' (expected patch|minor|major|X.Y.Z)" ;;
+  esac
+fi
+echo "release: $CUR -> $NEW"
+
+# --- Step 3: guard against collisions ---------------------------------------
+[[ -z "$(git tag -l "v$NEW")" ]] || die "tag v$NEW already exists locally"
+[[ -z "$(git ls-remote --tags origin "v$NEW")" ]] || die "tag v$NEW already exists on origin"
+CODE="$(curl -s -o /dev/null -w '%{http_code}' "https://pypi.org/pypi/awscost/$NEW/json" || echo 000)"
+[[ "$CODE" != "200" ]] || die "awscost $NEW is already on PyPI"
+
+# --- Step 4: edit pyproject.toml --------------------------------------------
+# Only the leading `version = "..."` (the project version), not deps.
+perl -i -pe 'BEGIN{$n=0} if(!$n && /^version = "/){s/^version = "[^"]+"/version = "'"$NEW"'"/; $n=1}' pyproject.toml
+
+# --- Step 5: sanity gate (mirror scripts/ci.sh run-test) --------------------
+if ! ruff check src tests || ! ruff format --check --diff ./ || ! pytest -q; then
+  git checkout pyproject.toml
+  die "sanity gate failed; reverted pyproject.toml"
+fi
+
+# --- Step 6: commit to master, tag locally, then push both ------------------
+# Tag locally BEFORE pushing so that if the tag push fails after master is
+# pushed, the tag already exists and recovery is a single re-push.
+git add pyproject.toml
+git commit -m "Release v$NEW"
+git tag "v$NEW"
+git push origin master
+
+# --- Step 7: push the tag (this triggers the publish workflow) --------------
+if ! git push origin "v$NEW"; then
+  die "master is pushed but tag push failed. Recover with: git push origin v$NEW"
+fi
+
+# --- Step 8: confirm the publish --------------------------------------------
+# The release is already committed and tagged; this only waits for the async
+# publish workflow. A timeout here means "not confirmed yet", NOT "failed".
+echo "release: tag pushed; waiting for PyPI to publish v$NEW ..."
+for _ in $(seq 1 30); do
+  CODE="$(curl -s -o /dev/null -w '%{http_code}' "https://pypi.org/pypi/awscost/$NEW/json" || echo 000)"
+  if [[ "$CODE" == "200" ]]; then
+    echo "release: published https://pypi.org/project/awscost/$NEW/"
+    exit 0
+  fi
+  sleep 10
+done
+echo "release: v$NEW not on PyPI yet (publish may still be running) — check the Actions tab" >&2
+exit 2


### PR DESCRIPTION
## Summary
- Adds a Claude Code skill `awscost-release` under `.claude/skills/`.
- `release.sh` bumps the `version` in `pyproject.toml`, commits it to `master`, and pushes a matching `v<version>` tag that triggers the existing `release` workflow (PyPI Trusted Publisher / OIDC — no token).
- The tag is always derived from `pyproject.toml`, so the packaged version and the tag never drift.

## Guards & gates
- Requires `master`, a clean tree, and up-to-date with origin.
- Stops on collision: tag exists locally/on origin, or the version is already on PyPI.
- Sanity gate mirrors `scripts/ci.sh run-test` (`ruff check`, `ruff format --check`, `pytest`) and reverts on failure before anything is pushed.
- Polls PyPI after the tag push and reports the published URL.

## Usage
```bash
.claude/skills/awscost-release/release.sh [patch|minor|major|X.Y.Z]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)